### PR TITLE
Changes CHIP_PWM_Adapter to a class declaration

### DIFF
--- a/Adafruit_GPIO/PWM.py
+++ b/Adafruit_GPIO/PWM.py
@@ -109,7 +109,7 @@ class BBIO_PWM_Adapter(object):
         self.bbio_pwm.stop(pin)
 
 
-def CHIP_PWM_Adapter(object):
+class CHIP_PWM_Adapter(object):
     """PWM implementation for the CHIP using sysfs"""
 
     def __init__(self, chipio_pwm):


### PR DESCRIPTION
get_platform_pwm was returning a Nonetype instead of a CHIP_PWM_Adapter. Then I noticed that CHIP_PWM_Adapter was being declaring with "def". Should it be changed to "class"?
